### PR TITLE
fix: replace all node_modules not only the first one

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ const plugin = (moduleName: string = "external"): Plugin => {
       const changedFiles: string[] = [];
       Object.entries(bundle).forEach(([fileName, chunkInfo]) => {
         if (fileName.includes("node_modules")) {
-          const newFileName = fileName.replace("node_modules", moduleName);
+          const newFileName = fileName.replace(/node_modules/g, moduleName);
           chunkInfo.fileName = newFileName;
           changedFiles.push(fileName);
         }
@@ -72,10 +72,7 @@ const plugin = (moduleName: string = "external"): Plugin => {
 
                   if (req && req.value.includes("node_modules")) {
                     const { start, end } = req;
-                    const newPath = req.value.replace(
-                      "node_modules",
-                      moduleName
-                    );
+                    const newPath = req.value.replace(/node_modules/g, moduleName);
 
                     magicString.overwrite(start, end, `'${newPath}'`);
                   }


### PR DESCRIPTION
We areusing `replace("node_modules", moduleName)`   in  filename and import source. but only replace the first matches "node_modules".

nested node_modules is very common in today's nodejs