### PR TITLE
Option to disable source map generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ export default {
 
 It takes a string and will rename files and mentions of `node_module` to the provided string. By default it's `external`.
 
+It has optional second parameter `sourceMap` which defaults to `true` and can disable source map generation:
+
+```js
+plugins: [renameNodeModules("ext", false)]
+```
+
 ### Credit
 
 Base idea taken from https://github.com/GiG/rollup-plugin-rename-extensions

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ function getImportSource(node: any): Node | false {
 
 const importNodeTypes = [NodeType.ImportDeclaration, NodeType.CallExpression];
 
-const plugin = (moduleName: string = "external"): Plugin => {
+const plugin = (moduleName: string = "external", sourceMaps = true): Plugin => {
   return {
     name: "rename-external-node-modules",
     generateBundle(_, bundle) {
@@ -80,7 +80,9 @@ const plugin = (moduleName: string = "external"): Plugin => {
               },
             });
 
-            chunkInfo.map = magicString.generateMap();
+            if (sourceMaps) {
+              chunkInfo.map = magicString.generateMap();
+            }
             chunkInfo.code = magicString.toString();
           }
         }


### PR DESCRIPTION
Hey @Lazyuki! 

In some situations, this plugin produces empty source maps like [this](https://gist.github.com/11bit/361ca90e52df4fc7baa90353dd1f68d6). It is hard to track where the problem is but as a quick solution we can add an option to disable source map generation and let rollup generate them down the line. 
This option exists in similar plugins like https://github.com/remaxjs/rollup-plugin-rename so this looks like a legit solution.
WDYT? 
